### PR TITLE
Used native method to create array iterator

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,9 @@
-
-module.exports = function arrayIter(arr) {
+function arrayIterNative(arr) {
   return arr[Symbol.iterator]();
 }
+
+function* arrayIter(arr) {
+  for (var i = 0, len = arr.length; i < len; i++) yield arr[i];
+}
+
+module.exports = typeof Symbol === 'undefined' || typeof Symbol.iterator === 'undefined' ? arrayIter : arrayIterNative;

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
 
-module.exports = function* arrayIter(arr) {
-  for (var i = 0, len = arr.length; i < len; i++) yield arr[i];
+module.exports = function arrayIter(arr) {
+  return arr[Symbol.iterator]();
 }


### PR DESCRIPTION
According to browsers compatibility for [Symbol](https://developer.mozilla.org/ru/docs/Web/JavaScript/Reference/Global_Objects/Symbol) and [Generators](https://developer.mozilla.org/ru/docs/Web/JavaScript/Reference/Statements/function*) we can use `Symbol.iterator` instead of creating array iterator using `yield`.
